### PR TITLE
feat(core): discover_data_files ignores hidden directories

### DIFF
--- a/quiverfs-core/src/file_discovery.rs
+++ b/quiverfs-core/src/file_discovery.rs
@@ -111,7 +111,7 @@ mod tests {
 
         // Should find only visible files in visible directories
         for file in &["a.arrow", "b.feather", "c.parquet", "d.arrow"] {
-            assert!(found_files.contains(&file.to_string()), &format!("Missing {}", file));
+            assert!(found_files.contains(&file.to_string()), "Missing {file}");
         }
 
         // Should NOT find hidden files or files in hidden directories


### PR DESCRIPTION
Update the discover_data_files function to skip hidden directories and hidden files (those starting with a .) during recursive file discovery. This prevents accidental traversal of system folders, temporary caches, or user-specific data that should not be parsed.

Closes #13