### PR TITLE
feat(fuse): gains simple Fuse CLI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install FUSE dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libfuse-dev fuse
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +568,22 @@ dependencies = [
  "crc32fast",
  "libz-rs-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fuser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy",
 ]
 
 [[package]]
@@ -804,6 +826,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +933,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parquet"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1013,14 @@ dependencies = [
  "parquet",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "quiverfs-fuse"
+version = "0.1.0"
+dependencies = [
+ "fuser",
+ "libc",
 ]
 
 [[package]]
@@ -1104,6 +1156,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snap"
@@ -1263,6 +1321,28 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
-members = [ "quiverfs-cli",
-    "quiverfs-core",
+members = [
     "quiverfs-cli",
+    "quiverfs-core",
+    "quiverfs-fuse",
 ]
 resolver = "3"

--- a/quiverfs-fuse/Cargo.toml
+++ b/quiverfs-fuse/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "quiverfs-fuse"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+fuser = "0.15.1"
+libc = "0.2.174"

--- a/quiverfs-fuse/src/fs/hello_fs.rs
+++ b/quiverfs-fuse/src/fs/hello_fs.rs
@@ -1,0 +1,120 @@
+use fuser::{
+    FileAttr, FileType, Filesystem, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry, Request,
+};
+use std::ffi::OsStr;
+use std::time::{Duration, UNIX_EPOCH};
+
+const TTL: Duration = Duration::from_secs(1);
+const HELLO_DIR_ATTR: FileAttr = FileAttr {
+    ino: 1,
+    size: 0,
+    blocks: 0,
+    atime: UNIX_EPOCH,
+    mtime: UNIX_EPOCH,
+    ctime: UNIX_EPOCH,
+    crtime: UNIX_EPOCH,
+    kind: FileType::Directory,
+    perm: 0o755,
+    nlink: 2,
+    uid: 501,
+    gid: 20,
+    rdev: 0,
+    flags: 0,
+    blksize: 512,
+};
+
+const HELLO_TXT_ATTR: FileAttr = FileAttr {
+    ino: 2,
+    size: 20,
+    blocks: 1,
+    atime: UNIX_EPOCH,
+    mtime: UNIX_EPOCH,
+    ctime: UNIX_EPOCH,
+    crtime: UNIX_EPOCH,
+    kind: FileType::RegularFile,
+    perm: 0o644,
+    nlink: 1,
+    uid: 501,
+    gid: 20,
+    rdev: 0,
+    flags: 0,
+    blksize: 512,
+};
+
+pub struct HelloFS;
+
+impl HelloFS {
+    pub fn new() -> Self {
+        HelloFS
+    }
+}
+
+impl Filesystem for HelloFS {
+    fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        if parent == 1 && name.to_str() == Some("hello.txt") {
+            reply.entry(&TTL, &HELLO_TXT_ATTR, 0);
+        } else {
+            reply.error(libc::ENOENT);
+        }
+    }
+
+    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+        match ino {
+            1 => reply.attr(&TTL, &HELLO_DIR_ATTR),
+            2 => reply.attr(&TTL, &HELLO_TXT_ATTR),
+            _ => reply.error(libc::ENOENT),
+        }
+    }
+
+    fn read(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        size: u32, // Changed from _size to size since we'll use it
+        _flags: i32,
+        _lock: Option<u64>,
+        reply: ReplyData,
+    ) {
+        if ino == 2 {
+            let content = b"Hello from quiver-fs!";
+            let start = offset as usize;
+            let end = std::cmp::min(start + size as usize, content.len());
+            if start >= content.len() {
+                reply.data(&[]);
+            } else {
+                reply.data(&content[start..end]);
+            }
+        } else {
+            reply.error(libc::ENOENT);
+        }
+    }
+
+    fn readdir(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: ReplyDirectory,
+    ) {
+        if ino != 1 {
+            reply.error(libc::ENOENT);
+            return;
+        }
+
+        let entries = vec![
+            (1, FileType::Directory, "."),
+            (1, FileType::Directory, ".."),
+            (2, FileType::RegularFile, "hello.txt"),
+        ];
+
+        for (i, entry) in entries.into_iter().enumerate().skip(offset as usize) {
+            if reply.add(entry.0, (i + 1) as i64, entry.1, entry.2) {
+                break;
+            }
+        }
+        reply.ok();
+    }
+}

--- a/quiverfs-fuse/src/fs/mod.rs
+++ b/quiverfs-fuse/src/fs/mod.rs
@@ -1,0 +1,1 @@
+pub mod hello_fs;

--- a/quiverfs-fuse/src/main.rs
+++ b/quiverfs-fuse/src/main.rs
@@ -1,0 +1,12 @@
+use fuser::MountOption;
+mod fs;
+
+fn main() {
+    let mountpoint = std::env::args()
+    .nth(1)
+    .unwrap_or_else(|| "/tmp/quiver-fs".to_string());
+
+    let filesystem = fs::hello_fs::HelloFS::new();
+
+    fuser::mount2(filesystem, &mountpoint, &[MountOption::RO]).unwrap();
+}


### PR DESCRIPTION
Gains a `quiverfs-fuse` crate. 

Running th efollowing will mount a virtual filesystem at the specified directory:
``` bash
mkdir /tmp/mounting/directory
cargo run --bin quiverfs-fuse /tmp/mounting/directory
```

Then, running:
``` bash
cat /tmp/mounting/directory/hello.txt
```

Will print: 
"Hello from quiver-fs!"

Note: GitHub action runner also gains a system dependency on Fuse.

Closes #25 
